### PR TITLE
Add 'Show all students' checkbox to tutoring request forms

### DIFF
--- a/client/src/components/BulkTutoring.js
+++ b/client/src/components/BulkTutoring.js
@@ -47,6 +47,8 @@ const BulkTutoring = () => {
   
   // State for students management
   const [allStudents, setAllStudents] = useState([]);
+  const [myStudents, setMyStudents] = useState([]);
+  const [showAllStudents, setShowAllStudents] = useState(false);
   const [selectedStudents, setSelectedStudents] = useState([]);
   const [selectedStudentId, setSelectedStudentId] = useState('');
   // const [studentFilter, setStudentFilter] = useState('');
@@ -68,15 +70,7 @@ const BulkTutoring = () => {
            try {
              setFetchingStudents(true);
              const response = await apiService.getStudents();
-             const filteredStudents = response.data.filter(student =>{
-               return(
-                 student?.R1Id===parseInt(teacherId) ||
-                 student?.R2Id===parseInt(teacherId) ||
-                 student?.R4Id===parseInt(teacherId) ||
-                 student?.R5Id===parseInt(teacherId)
-               );
-             });
-             const processedStudents = filteredStudents.map(student =>{
+             const processStudent = (student) => {
                let lunchPeriod = null;
                if(student.teachers && student.teachers.RR && student.teachers.RR.lunch){
                  lunchPeriod = student.teachers.RR.lunch;
@@ -88,13 +82,23 @@ const BulkTutoring = () => {
                  lunchPeriod = student.lunch;
                }
                const fullName = `${student.first_name} ${student.last_name}`;
-             return {
-               ...student,
-               lunchPeriod,
-               displayName: lunchPeriod ? `[${lunchPeriod}] ${fullName}` : fullName
+               return {
+                 ...student,
+                 lunchPeriod,
+                 displayName: lunchPeriod ? `[${lunchPeriod}] ${fullName}` : fullName
                };
-             });
-             setAllStudents(processedStudents);
+             };
+             const processedAll = response.data.map(processStudent);
+             const processedMy = response.data
+               .filter(student =>
+                 student?.R1Id===parseInt(teacherId) ||
+                 student?.R2Id===parseInt(teacherId) ||
+                 student?.R4Id===parseInt(teacherId) ||
+                 student?.R5Id===parseInt(teacherId)
+               )
+               .map(processStudent);
+             setAllStudents(processedAll);
+             setMyStudents(processedMy);
              setFetchingStudents(false);
            } catch (err) {
              console.error('Error fetching students:', err);
@@ -375,21 +379,27 @@ const BulkTutoring = () => {
               <Typography variant="subtitle1" gutterBottom>
                 Student Selection
               </Typography>
-              
-              {/* <TextField
-                fullWidth
-                margin="normal"
-                label="Filter Students"
-                value={studentFilter}
-                onChange={(e) => setStudentFilter(e.target.value)}
-                disabled={loading}
+
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={showAllStudents}
+                    onChange={(e) => {
+                      setShowAllStudents(e.target.checked);
+                      setSelectedStudentId('');
+                    }}
+                    disabled={fetchingStudents || loading}
+                  />
+                }
+                label="Show all students (for review sessions)"
+                sx={{ mb: 1 }}
               />
-               */}
+
             <Autocomplete
   id="student-autocomplete"
-  options={allStudents}
+  options={showAllStudents ? allStudents : myStudents}
   getOptionLabel={(option) => option.displayName || `${option.first_name || ''} ${option.last_name || ''}`.trim()}
-  value={allStudents.find(student => student.id === selectedStudentId) || null}
+  value={(showAllStudents ? allStudents : myStudents).find(student => student.id === selectedStudentId) || null}
   onChange={(event, newValue) => {
     const studentId = newValue ? newValue.id : '';
     setSelectedStudentId(studentId);

--- a/client/src/components/TutoringRequestForm.js
+++ b/client/src/components/TutoringRequestForm.js
@@ -24,7 +24,9 @@ import {useTutoring} from '../contexts/TutoringContext.js';
 
 const TutoringRequestForm = () => {
   const { createSession, confirmOverride, dismissOverride, conflictDetails } = useTutoring();
-  const [students, setStudents] = useState([]);
+  const [allStudents, setAllStudents] = useState([]);
+  const [myStudents, setMyStudents] = useState([]);
+  const [showAllStudents, setShowAllStudents] = useState(false);
   const [selectedStudent, setSelectedStudent] = useState('');
   const [selectedDate, setSelectedDate] = useState(null);
   const [studentLunchPeriod, setStudentLunchPeriod] = useState(null);
@@ -47,15 +49,7 @@ const TutoringRequestForm = () => {
       try {
         setFetchingStudents(true);
         const response = await apiService.getStudents();
-        const filteredStudents = response.data.filter(student =>{
-          return(
-            student?.R1Id===parseInt(teacherId) ||
-            student?.R2Id===parseInt(teacherId) ||
-            student?.R4Id===parseInt(teacherId) ||
-            student?.R5Id===parseInt(teacherId)
-          );
-        });
-        const processedStudents = filteredStudents.map(student =>{
+        const processStudent = (student) => {
           let lunchPeriod = null;
           if(student.teachers && student.teachers.RR && student.teachers.RR.lunch){
             lunchPeriod = student.teachers.RR.lunch;
@@ -67,13 +61,23 @@ const TutoringRequestForm = () => {
             lunchPeriod = student.lunch;
           }
           const fullName = `${student.first_name} ${student.last_name}`;
-        return {
-          ...student,
-          lunchPeriod,
-          displayName: lunchPeriod ? `[${lunchPeriod}] ${fullName}` : fullName
+          return {
+            ...student,
+            lunchPeriod,
+            displayName: lunchPeriod ? `[${lunchPeriod}] ${fullName}` : fullName
           };
-        });
-        setStudents(processedStudents);
+        };
+        const processedAll = response.data.map(processStudent);
+        const processedMy = response.data
+          .filter(student =>
+            student?.R1Id===parseInt(teacherId) ||
+            student?.R2Id===parseInt(teacherId) ||
+            student?.R4Id===parseInt(teacherId) ||
+            student?.R5Id===parseInt(teacherId)
+          )
+          .map(processStudent);
+        setAllStudents(processedAll);
+        setMyStudents(processedMy);
         setFetchingStudents(false);
       } catch (err) {
         console.error('Error fetching students:', err);
@@ -89,7 +93,7 @@ const TutoringRequestForm = () => {
     const studentId = event.target.value;
     setSelectedStudent(studentId);
 
-    const student = students.find(s => s.id === studentId);
+    const student = allStudents.find(s => s.id === studentId) || myStudents.find(s => s.id === studentId);
     if(student){
       try{
         const rrTeacherId = student.RRId;
@@ -213,12 +217,28 @@ const TutoringRequestForm = () => {
         {success && <Alert severity="success" sx={{ mb: 2 }}>{success}</Alert>}
         
         <Box component="form" onSubmit={handleSubmit}>
-          
+
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={showAllStudents}
+                onChange={(e) => {
+                  setShowAllStudents(e.target.checked);
+                  setSelectedStudent('');
+                  setStudentLunchPeriod(null);
+                }}
+                disabled={fetchingStudents || loading}
+              />
+            }
+            label="Show all students (for review sessions)"
+            sx={{ mb: 1 }}
+          />
+
           <Autocomplete
             id="student-autocomplete"
-            options={students}
+            options={showAllStudents ? allStudents : myStudents}
             getOptionLabel={(option) => option.name || `${option.first_name || ''} ${option.last_name || ''}`.trim()}
-            value={students.find(student => student.id === selectedStudent) || null}
+            value={(showAllStudents ? allStudents : myStudents).find(student => student.id === selectedStudent) || null}
             onChange={(event, newValue) => {
               const studentId = newValue ? newValue.id : '';
               handleStudentChange({target: {value: studentId}});


### PR DESCRIPTION
Teachers hosting review sessions sometimes need to request students not assigned to their classes. Both the individual and bulk tutoring forms now include a checkbox labeled "Show all students (for review sessions)" that, when checked, expands the student dropdown from the teacher's own students to all enrolled students in the system.

Default behavior (unchecked) is unchanged — teachers see only their own students. No backend or database changes are required; the existing /api/students endpoint already returns all students.

https://claude.ai/code/session_01Q9m4kWBNZtpip1x4tjNSFQ