### PR TITLE
Refresh session list after sending calendar invites

### DIFF
--- a/client/src/components/CalendarInviteButton.js
+++ b/client/src/components/CalendarInviteButton.js
@@ -2,8 +2,10 @@ import React, { useState, useEffect } from 'react';
 import { Button, CircularProgress, Snackbar, Alert } from '@mui/material';
 import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
 import apiService from '../utils/apiService';
+import { useTutoring } from '../contexts/TutoringContext';
 
 function CalendarInviteButton() {
+  const { refreshSessions } = useTutoring();
   const [pendingCount, setPendingCount] = useState(0);
   const [sending, setSending] = useState(false);
   const [snackbar, setSnackbar] = useState({ open: false, message: '', severity: 'success' });
@@ -36,6 +38,7 @@ function CalendarInviteButton() {
       });
       
       fetchPendingCount();
+      refreshSessions();
     } catch (err) {
       console.error('Error sending invites:', err);
       setSnackbar({


### PR DESCRIPTION
After sendCalendarInvites() succeeds, call refreshSessions() so the TutoringRequestList and TutoringEvents page immediately reflect the updated invite_sent status without requiring a manual page refresh.

https://claude.ai/code/session_01HB6JK2w5piBGe1zhiZybsN