### PR TITLE
Add per-row manual invite toggle to handle teacher-sent invites

### DIFF
--- a/client/src/components/TutoringRequestList.js
+++ b/client/src/components/TutoringRequestList.js
@@ -13,9 +13,11 @@ import {
   Chip,
   TextField,
   InputAdornment,
-  Alert
+  Alert,
+  IconButton,
+  Tooltip
 } from '@mui/material';
-import { Search as SearchIcon } from '@mui/icons-material';
+import { Search as SearchIcon, CheckCircleOutline as CheckCircleOutlineIcon, Undo as UndoIcon } from '@mui/icons-material';
 import { format, parseISO } from 'date-fns';
 import {useTutoring} from '../contexts/TutoringContext';
 import CalendarInviteButton from './CalendarInviteButton';
@@ -25,7 +27,7 @@ const TutoringRequestList = () => {
   const [searchTerm, setSearchTerm] = useState('');
   
   const teacherId = localStorage.getItem('teacherId');
-  const {sessions, error, cancelSession} = useTutoring();
+  const {sessions, error, cancelSession, markInviteSent, unmarkInviteSent} = useTutoring();
   const getFullName = (person) => {
     if (!person?.first_name || !person?.last_name) return '';
     return `${person.first_name} ${person.last_name}`;
@@ -166,11 +168,29 @@ const TutoringRequestList = () => {
                       />
                     </TableCell>
                     <TableCell>
-                      <Chip 
-                        label={request.invite_sent ? "Invited" : "Pending"} 
-                        color={request.invite_sent ? "success" : "warning"} 
-                        size="small" 
-                      />
+                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                        {request.invite_sent && request.calendar_event_id ? (
+                          <Chip label="Invited" color="success" size="small" />
+                        ) : request.invite_sent ? (
+                          <Chip label="Invited (Manual)" color="info" size="small" />
+                        ) : (
+                          <Chip label="Pending" color="warning" size="small" />
+                        )}
+                        {!request.invite_sent && (
+                          <Tooltip title="Mark as manually sent">
+                            <IconButton size="small" onClick={() => markInviteSent(request.id)}>
+                              <CheckCircleOutlineIcon fontSize="small" />
+                            </IconButton>
+                          </Tooltip>
+                        )}
+                        {request.invite_sent && !request.calendar_event_id && (
+                          <Tooltip title="Undo manual mark">
+                            <IconButton size="small" onClick={() => unmarkInviteSent(request.id)}>
+                              <UndoIcon fontSize="small" />
+                            </IconButton>
+                          </Tooltip>
+                        )}
+                      </Box>
                     </TableCell>
                     <TableCell align="right">
                       {request.status === 'active' && 

--- a/client/src/contexts/TutoringContext.js
+++ b/client/src/contexts/TutoringContext.js
@@ -136,18 +136,30 @@ export const TutoringProvider = ({children}) => {
         fetchSessions();
     }, []);
 
+    const markInviteSent = async (requestId) => {
+        await apiService.markInviteSent(requestId);
+        await fetchSessions();
+    };
+
+    const unmarkInviteSent = async (requestId) => {
+        await apiService.unmarkInviteSent(requestId);
+        await fetchSessions();
+    };
+
     const value = {
-        sessions, 
+        sessions,
         loading,
         error,
-        conflictDetails, 
-        createSession, 
-        confirmOverride, 
-        dismissOverride, 
+        conflictDetails,
+        createSession,
+        confirmOverride,
+        dismissOverride,
         cancelSession,
         getSessionsForStudent,
-        checkPriorityForDate, 
-        refreshSessions: fetchSessions
+        checkPriorityForDate,
+        refreshSessions: fetchSessions,
+        markInviteSent,
+        unmarkInviteSent
     };
 
     return (

--- a/client/src/utils/apiService.js
+++ b/client/src/utils/apiService.js
@@ -137,6 +137,12 @@ const apiService = {
   },
   sendCalendarInvites: async () => {
     return await apiClient.post('/api/calendar/send-invites');
+  },
+  markInviteSent: async (requestId) => {
+    return await apiClient.patch(`/api/calendar/mark-sent/${requestId}`);
+  },
+  unmarkInviteSent: async (requestId) => {
+    return await apiClient.patch(`/api/calendar/unmark-sent/${requestId}`);
   }
 };
 

--- a/server/routes/calendar.js
+++ b/server/routes/calendar.js
@@ -55,16 +55,30 @@ router.post('/send-invites', auth, async (req, res) => {
       // Find existing event ID from any request in this group (sent or unsent)
       const existingEventId = group.requests.find(r => r.calendar_event_id)?.calendar_event_id;
 
+      // Exclude students whose requests are manually marked (invite_sent=true, calendar_event_id=null)
+      // so the app never sends a duplicate Google Calendar invite for teacher-handled students.
+      const manuallyMarkedStudentIds = new Set(
+        group.requests
+          .filter(r => r.invite_sent && !r.calendar_event_id)
+          .map(r => r.Student.id)
+      );
+      const groupAttendees = group.students
+        .filter(s => !manuallyMarkedStudentIds.has(s.id))
+        .map(student => ({
+          email: student.email,
+          displayName: `${student.first_name} ${student.last_name}`
+        }));
+
+      // If every student in this group was manually marked, skip the Google Calendar call
+      if (groupAttendees.length === 0) continue;
+
       const eventDetails = {
         summary: `RR Tutoring - ${req.user.subject}`,
         description: `Tutoring session today during Raptor Rotation.`,
         startDateTime: group.startDateTime,
         endDateTime: group.endDateTime,
-        // Include ALL students (sent + unsent) so existing attendees are not dropped
-        attendees: group.students.map(student => ({
-          email: student.email,
-          displayName: `${student.first_name} ${student.last_name}`
-        }))
+        // Include all non-manually-marked students so existing attendees are not dropped
+        attendees: groupAttendees
       };
 
       // Create or update the event
@@ -84,7 +98,7 @@ router.post('/send-invites', auth, async (req, res) => {
         eventId: event.id,
         date: group.date,
         timeSlot: group.timeSlot,
-        studentCount: group.students.length
+        studentCount: groupAttendees.length
       });
     }
 
@@ -123,6 +137,52 @@ router.get('/pending-count', auth, async (req, res) => {
     res.json({ pendingCount: count });
   } catch (err) {
     console.error('Error getting pending count:', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+// @route   PATCH /api/calendar/mark-sent/:id
+// @desc    Manually mark a tutoring request as invite-sent (teacher handled it outside the app)
+// @access  Private
+router.patch('/mark-sent/:id', auth, async (req, res) => {
+  try {
+    const request = await TutoringRequest.findOne({
+      where: { id: req.params.id, TeacherId: req.teacher.id }
+    });
+
+    if (!request) {
+      return res.status(404).json({ error: 'Request not found' });
+    }
+
+    await request.update({ invite_sent: true, invite_sent_at: new Date() });
+    res.json({ message: 'Marked as manually sent', request });
+  } catch (err) {
+    console.error('Error marking invite as sent:', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+// @route   PATCH /api/calendar/unmark-sent/:id
+// @desc    Undo a manual mark (only allowed when no Google Calendar event is attached)
+// @access  Private
+router.patch('/unmark-sent/:id', auth, async (req, res) => {
+  try {
+    const request = await TutoringRequest.findOne({
+      where: { id: req.params.id, TeacherId: req.teacher.id }
+    });
+
+    if (!request) {
+      return res.status(404).json({ error: 'Request not found' });
+    }
+
+    if (request.calendar_event_id) {
+      return res.status(400).json({ error: 'Cannot unmark an invite that was sent via the app' });
+    }
+
+    await request.update({ invite_sent: false, invite_sent_at: null });
+    res.json({ message: 'Invite unmarked', request });
+  } catch (err) {
+    console.error('Error unmarking invite:', err);
     res.status(500).json({ error: 'Server error' });
   }
 });


### PR DESCRIPTION
Adds a 'Mark as manually sent' icon button to each Pending row so teachers can flag students they've already invited outside the app. An undo button appears on manually-marked rows (blue 'Invited (Manual)' chip) in case of accidental clicks. App-sent rows (green 'Invited' chip with a Google event ID) cannot be undone.

On the backend, manually-marked students are excluded from Google Calendar attendee lists during batch sends, preventing duplicate invites. If every student in a time-slot group is manually marked, the Google Calendar call is skipped entirely.

No database schema changes — uses the existing invite_sent boolean and calendar_event_id nullable string (null = manual, set = app-sent).

https://claude.ai/code/session_01HB6JK2w5piBGe1zhiZybsN