### PR TITLE
Proactively refresh Google OAuth token before Calendar API calls

### DIFF
--- a/server/utils/calendarService.js
+++ b/server/utils/calendarService.js
@@ -38,6 +38,15 @@ async function getOAuth2Client(teacherId) {
     }
   });
 
+  // Proactively ensure the token is fresh before any Calendar API call.
+  // Silent if valid; silently refreshes via refresh_token if expired; throws a
+  // user-friendly message if the refresh_token itself is invalid or revoked.
+  try {
+    await oauth2Client.getAccessToken();
+  } catch (err) {
+    throw new Error('Google Calendar authorization has expired. Please sign out and sign back in.');
+  }
+
   return oauth2Client;
 }
 


### PR DESCRIPTION
Replace implicit auto-refresh (relied on by the googleapis request pipeline, which can fail inconsistently) with an explicit oauth2Client.getAccessToken() call in getOAuth2Client(). This forces a synchronous check every time a Calendar API call is about to be made:

- Token still valid → returns immediately, no network call
- Token expired → silently refreshes using the stored refresh_token, fires the existing tokens event (which persists the new token to DB), then continues transparently — teacher sees nothing
- Refresh token revoked/invalid → throws a user-friendly message rather than the cryptic library error "no fresh token was available"

Fixes the 500 error teachers hit after being logged in for extended periods without the token being proactively renewed.

https://claude.ai/code/session_01HB6JK2w5piBGe1zhiZybsN